### PR TITLE
Fix flagging of embedding failure & and nbformat to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 dwave-ocean-sdk==2.1.1
 
 jupyter
-jupyter_contrib_nbextensions==0.5.1
-autopep8==1.3.2
+jupyter_contrib_nbextensions
+autopep8
 bokeh==0.12.15
 
 nbformat

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ jupyter
 jupyter_contrib_nbextensions==0.5.1
 autopep8==1.3.2
 bokeh==0.12.15
+
+nbformat

--- a/tests/test_jn.py
+++ b/tests/test_jn.py
@@ -40,13 +40,18 @@ def collect_jn_errors(nb):
 
     return errors
 
+def embedding_fail(error_list):
+    if error_list != [] and error_list[0].evalue == 'no embedding found':
+        return True
+    return False
+
 def robust_run_jn(jn, timeout, retries):
 
     run_num = 1
     notebook = run_jn(jn, timeout)
     errors = collect_jn_errors(notebook)
 
-    while 'no embedding found' in errors and run_num < retries:
+    while embedding_fail(errors) and run_num < retries:
         run_num += 1
         notebook = run_jn(jn, timeout)
         errors = collect_jn_errors(notebook)

--- a/tests/test_jn.py
+++ b/tests/test_jn.py
@@ -41,9 +41,7 @@ def collect_jn_errors(nb):
     return errors
 
 def embedding_fail(error_list):
-    if error_list != [] and error_list[0].evalue == 'no embedding found':
-        return True
-    return False
+    return error_list and 'no embedding found' in error_list
 
 def robust_run_jn(jn, timeout, retries):
 
@@ -87,4 +85,3 @@ class TestJupyterNotebook(unittest.TestCase):
 
         # Section A Real-World Example, second code cell with text output
         self.assertIn("sign", cell_text(nb, 24))
-


### PR DESCRIPTION
@randomir, I should have tested this proposed [code change](https://github.com/dwave-examples/structural-imbalance-notebook/pull/3#discussion_r469889934), the errors format is not a simple string, it's a dict. This change flags an embedding failure if it's the first failure of the run and adds the `nbformat` to requirements. 