### PR TITLE
Remove nbconvert from requirements.txt to fix failing tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ jupyter
 jupyter_contrib_nbextensions
 autopep8
 bokeh<3
-
-nbconvert==5.6.1


### PR DESCRIPTION
Problem described [here](https://github.com/jupyter/jupyter_client/issues/637). 

Same as https://github.com/dwave-examples/hybrid-computing-notebook/pull/16